### PR TITLE
Replace Array-based routes system with Hash-based

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,8 +74,3 @@ More at [Wiki](https://github.com/AlexWayfer/flame/wiki) and in `example/` direc
 ## Benchmark
 
 The last benchmark can be viewed [here](https://github.com/AlexWayfer/bench-micro).
-
-## TODO
-
-* Create a command-line utility (for the generation of the project)
-* ...

--- a/Rakefile
+++ b/Rakefile
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 task :spec do
-	sh 'bacon -a -q'
+	sh 'bacon -a -s'
 end
 
 task default: :spec

--- a/flame.gemspec
+++ b/flame.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
 
 	s.add_runtime_dependency 'rack', '~> 2'
 	s.add_runtime_dependency 'tilt', '>= 2.0', '< 3'
-	s.add_runtime_dependency 'gorilla-patch', '~> 2', '>= 2.0.0'
+	s.add_runtime_dependency 'gorilla-patch', '~> 2', '>= 2.3.0'
 	s.add_runtime_dependency 'thor', '~> 0'
 
 	s.add_development_dependency 'rubocop', '~> 0.48'

--- a/lib/flame/application.rb
+++ b/lib/flame/application.rb
@@ -24,7 +24,7 @@ module Flame
 				app.config = Config.new(
 					app,
 					default_config_dirs(
-						root_dir: File.dirname(caller[0].split(':')[0])
+						root_dir: File.dirname(caller(1..1).first.split(':')[0])
 					).merge(
 						environment: ENV['RACK_ENV'] || 'development'
 					)

--- a/lib/flame/controller/with_actions.rb
+++ b/lib/flame/controller/with_actions.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+module Flame
+	## Declaration of `.with_actions` method and concomitants
+	class Controller
+		class << self
+			## Re-define public instance method from parent
+			## @example Inherit controller with parent actions by method
+			##   class MyController < BaseController.with_actions
+			##   end
+			## @example Define actions from module in controller
+			##   class MyController < BaseController
+			##     include with_actions Module1
+			##     include with_actions Module2
+			##     ....
+			##   end
+			def with_actions(mod = nil)
+				return mod.extend(ModuleActions) if mod
+				@with_actions ||= Class.new(self) { extend ParentActions }
+			end
+		end
+
+		## Extension for modules whose public methods will be defined as actions
+		## via including
+		module ModuleActions
+			def included(ctrl)
+				public_instance_methods.each do |meth|
+					ctrl.send :define_method, meth, public_instance_method(meth)
+				end
+			end
+		end
+
+		## Module for public instance methods re-defining from superclass
+		## @example Inherit controller with parent actions without forbidden
+		## actions by `extend`
+		##   class MyController < BaseController
+		##     FORBIDDEN_ACTIONS = %[foo bar baz].freeze
+		##     extend Flame::Controller::ParentActions
+		##   end
+		module ParentActions
+			def inherited(ctrl)
+				ctrl.define_parent_actions
+			end
+
+			def self.extended(ctrl)
+				ctrl.define_parent_actions
+			end
+
+			def define_parent_actions
+				(superclass.actions - self::FORBIDDEN_ACTIONS).each do |public_method|
+					um = superclass.public_instance_method(public_method)
+					define_method public_method, um
+				end
+			end
+		end
+	end
+end

--- a/lib/flame/router/route.rb
+++ b/lib/flame/router/route.rb
@@ -7,73 +7,25 @@ module Flame
 	class Router
 		## Class for Route in Router.routes
 		class Route
-			attr_reader :method, :controller, :action, :path
+			attr_reader :controller, :action
 
-			def initialize(controller, action, method, ctrl_path, action_path)
+			## @param controller [Flame::Controller] controller
+			## @param action [Symbol] action
+			def initialize(controller, action)
 				@controller = controller
 				@action = action
-				@method = method.to_sym.upcase
-				## Make path by controller method with parameners
-				action_path = Flame::Path.new(action_path).adapt(controller, action)
-				## Merge action path with controller path
-				@path = Flame::Path.new(ctrl_path, action_path)
-				Validators::RouteArgumentsValidator.new(
-					@controller, action_path, @action
-				).valid?
-				freeze
-			end
-
-			def freeze
-				@path.freeze
-				super
-			end
-
-			## Compare attributes for `Router.find_route`
-			## @param attrs [Hash] Hash of attributes for comparing
-			def compare_attributes(attrs)
-				attrs.each do |name, value|
-					next true if compare_attribute(name, value)
-					break false
-				end
 			end
 
 			## Method for Routes comparison
+			## @param other [Flame::Router::Route] other route
+			## @return [true, false] equal or not
 			def ==(other)
-				%i[controller action method path].reduce(true) do |result, method|
+				return false unless other.is_a? self.class
+				%i[controller action].reduce(true) do |result, method|
 					result && (
 						public_send(method) == other.public_send(method)
 					)
 				end
-			end
-
-			## Compare by:
-			## 1. path parts count (more is matter);
-			## 2. args position (father is matter);
-			## 3. HTTP-method (default).
-			def <=>(other)
-				path_result = other.path <=> path
-				return path_result unless path_result.zero?
-				method <=> other.method
-			end
-
-			private
-
-			## Helpers for `compare_attributes`
-			def compare_attribute(name, value)
-				case name
-				when :method
-					compare_method(value)
-				when :path
-					path.match? value
-				else
-					send(name) == value
-				end
-			end
-
-			def compare_method(request_method)
-				request_method = request_method.upcase.to_sym
-				request_method = :GET if request_method == :HEAD
-				method.upcase.to_sym == request_method
 			end
 		end
 	end

--- a/lib/flame/router/routes.rb
+++ b/lib/flame/router/routes.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+module Flame
+	class Router
+		## Custom Hash for routes
+		class Routes < Hash
+			## @param path_parts [Array<String, Flame::Path, Flame::Path::Part>]
+			##   path parts for nested keys
+			## @example Initialize without keys
+			##   Flame::Router::Routes.new # => {}
+			## @example Initialize with nested keys
+			##   Flame::Router::Routes.new('/foo/bar/baz')
+			##   # => { 'foo' => { 'bar' => { 'baz' => {} } } }
+			def initialize(*path_parts)
+				path = Flame::Path.new(*path_parts)
+				return if path.parts.empty?
+				nested_routes = self.class.new Flame::Path.new(*path.parts[1..-1])
+				# path.parts.reduce(result) { |hash, part| hash[part] ||= self.class.new }
+				self[path.parts.first] = nested_routes
+			end
+
+			## Move into Hash by equal key or through argument-key
+			## @param path_part [String, Flame::Path::Part, Symbol] requested key
+			## @return [Flame::Router::Routes, Flame::Router::Route, nil] found value
+			## @example Move by static path part
+			##   routes = Flame::Router::Routes.new('/foo/bar/baz')
+			##   routes['foo'] # => { 'bar' => { 'baz' => {} } }
+			## @example Move by argument
+			##   routes = Flame::Router::Routes.new('/foo/:first/bar')
+			##   routes['foo']['value'] # => { 'bar' => {} }
+			## @example Move by HTTP-method
+			##   routes = Flame::Router::Routes.new('/foo/bar')
+			##   routes['foo']['bar'][:GET] = 42
+			##   routes['foo']['bar'][:GET] # => 42
+			def [](path_part)
+				if path_part.is_a? String
+					path_part = Flame::Path::Part.new(path_part)
+				elsif !path_part.is_a?(Flame::Path::Part) && !path_part.is_a?(Symbol)
+					return
+				end
+				super(path_part) || super(first_req_arg_key)
+			end
+
+			## Move like multiple `#[]`
+			## @param path_parts [Array<String, Flame::Path, Flame::Path::Part>]
+			##   path or path parts as keys for digging
+			## @return [Flame::Router::Routes, Flame::Router::Route, nil] found value
+			## @example Move by static path part and argument
+			##   routes = Flame::Router::Routes.new('/foo/:first/bar')
+			##   routes.dig('foo', 'value') # => { 'bar' => {} }
+			def dig(*path_parts)
+				return self if path_parts.empty?
+				path_parts = Flame::Path.new(*path_parts).parts
+				endpoint =
+					self[path_parts.first] ||
+					find { |key, _value| key.is_a?(Flame::Path::Part) && key.arg? }
+						&.last
+				endpoint&.dig(*path_parts[1..-1])
+			end
+
+			## Dig through optional arguments as keys
+			## @return [Flame::Router::Routes] return most nested end-point
+			##   without optional arguments
+			def dig_through_opt_args
+				self[first_opt_arg_key]&.dig_through_opt_args || self
+			end
+
+			private
+
+			%i[req opt].each do |type|
+				define_method "first_#{type}_arg_key" do
+					keys.find do |key|
+						key.is_a?(Flame::Path::Part) && key.public_send("#{type}_arg?")
+					end
+				end
+			end
+		end
+	end
+end

--- a/lib/flame/validators.rb
+++ b/lib/flame/validators.rb
@@ -81,7 +81,7 @@ module Flame
 			def first_wrong_ordered_arguments
 				opt_arguments = action_arguments[:opt].zip(path_arguments[:opt])
 				opt_arguments.map! do |args|
-					args.map { |arg| Flame::Path::PathPart.new(arg, arg: :opt) }
+					args.map { |arg| Flame::Path::Part.new(arg, arg: :opt) }
 				end
 				opt_arguments.find do |action_argument, path_argument|
 					action_argument != path_argument

--- a/spec/unit/application/config_spec.rb
+++ b/spec/unit/application/config_spec.rb
@@ -16,13 +16,13 @@ describe Flame::Application::Config do
 	end
 
 	describe '#initialize' do
-		it 'should recieve application' do
+		it 'should receive application' do
 			config = @init.call(app: @app_class)
 			config.instance_variable_get(:@app)
 				.should.equal @app_class
 		end
 
-		it 'should recieve hash' do
+		it 'should receive hash' do
 			config = @init.call(hash: @hash)
 			config.should.equal @hash
 		end

--- a/spec/unit/application_spec.rb
+++ b/spec/unit/application_spec.rb
@@ -38,7 +38,7 @@ describe Flame::Application do
 	end
 
 	describe '.config=' do
-		it 'should recieve config' do
+		it 'should receive config' do
 			config = Flame::Application::Config.new(@app_class)
 			@app_class.config = config
 			@app_class.config.should.be.same_as config

--- a/spec/unit/controller_spec.rb
+++ b/spec/unit/controller_spec.rb
@@ -210,7 +210,7 @@ describe Flame::Controller do
 				@controller.response.location.should.equal @url
 			end
 
-			it 'should recieve status as last arument' do
+			it 'should receive status as last arument' do
 				@controller.redirect(@url, 301)
 				@controller.status.should.equal 301
 				@controller.response.location.should.equal @url
@@ -227,13 +227,12 @@ describe Flame::Controller do
 
 		describe 'by controller and action' do
 			it 'should write rediect to response' do
-				# binding.pry
 				@controller.redirect(AnotherControllerController, :hello, name: 'Alex')
 				@controller.status.should.equal 302
 				@controller.response.location.should.equal '/another/hello/Alex'
 			end
 
-			it 'should recieve status as last arument' do
+			it 'should receive status as last arument' do
 				@controller.redirect(
 					AnotherControllerController, :hello, { name: 'Alex' }, 301
 				)
@@ -259,7 +258,7 @@ describe Flame::Controller do
 				@controller.response.location.should.equal 'http://example.com'
 			end
 
-			it 'should recieve status as last arument' do
+			it 'should receive status as last arument' do
 				@controller.redirect URI::HTTP.build(host: 'example.com'), 301
 				@controller.status.should.equal 301
 				@controller.response.location.should.equal 'http://example.com'
@@ -337,7 +336,7 @@ describe Flame::Controller do
 				CONTENT
 		end
 
-		it 'should recieve options for Flame::Render' do
+		it 'should receive options for Flame::Render' do
 			@controller.view(:view, layout: false)
 				.should.equal "<h1>Hello, world!</h1>\n"
 		end

--- a/spec/unit/dispatcher/cookies_spec.rb
+++ b/spec/unit/dispatcher/cookies_spec.rb
@@ -14,7 +14,7 @@ describe Flame::Dispatcher::Cookies do
 	end
 
 	describe '#initialize' do
-		it 'should recieve cookies from Request object and Response object' do
+		it 'should receive cookies from Request object and Response object' do
 			-> { @init.call(@request.cookies, @response) }
 				.should.not.raise ArgumentError
 		end

--- a/spec/unit/path_spec.rb
+++ b/spec/unit/path_spec.rb
@@ -15,13 +15,20 @@ describe Flame::Path do
 	end
 
 	describe '.merge' do
-		it 'should merge from array' do
+		it 'should merge from Array of Strings' do
 			Flame::Path.merge(%w[foo bar baz])
 				.should.equal 'foo/bar/baz'
 		end
 
-		it 'should merge from multiple parts' do
+		it 'should merge from multiple parts as Strings' do
 			Flame::Path.merge('/foo/bar', '/baz/bat')
+				.should.equal '/foo/bar/baz/bat'
+		end
+
+		it 'should merge from multiple parts as Flame::Path' do
+			first_path = @init.call('/foo/bar')
+			second_path = @init.call('/baz/bat')
+			Flame::Path.merge(first_path, second_path)
 				.should.equal '/foo/bar/baz/bat'
 		end
 
@@ -32,12 +39,12 @@ describe Flame::Path do
 	end
 
 	describe '#initialize' do
-		it 'should recieve path as String' do
+		it 'should receive path as String' do
 			path = '/foo/bar'
 			@init.call(path).to_s.should.equal path
 		end
 
-		it 'should recieve many path parts' do
+		it 'should receive many path parts' do
 			@init.call('/foo', '/bar', 'baz').to_s.should.equal '/foo/bar/baz'
 		end
 	end
@@ -87,7 +94,7 @@ describe Flame::Path do
 				.should.equal true
 		end
 
-		it 'should recieve String' do
+		it 'should receive String' do
 			(@path == '/foo/:first/:second/:?third')
 				.should.equal true
 		end
@@ -126,32 +133,6 @@ describe Flame::Path do
 			path = '/baz/:first/:second/:?third'
 			@adapt_init.call(path: path)
 				.should.equal path
-		end
-	end
-
-	describe '#match?' do
-		it 'should return false for missing fixed parts' do
-			@path.match?('/none').should.equal false
-		end
-
-		it 'should return false for missing required arguments' do
-			@path.match?('/foo/bar').should.equal false
-		end
-
-		it 'should return false for long path' do
-			@path.match?('/foo/first/second/third/fourth').should.equal false
-		end
-
-		it 'should return true for all correct required arguments' do
-			@path.match?('/foo/first/second').should.equal true
-		end
-
-		it 'should return true for all correct required and optional arguments' do
-			@path.match?('/foo/first/second/third').should.equal true
-		end
-
-		it 'should receive Flame::Path' do
-			@path.match?(@init.call('/foo/first/second/third')).should.equal true
 		end
 	end
 
@@ -197,6 +178,16 @@ describe Flame::Path do
 
 		it 'should allow concatenate Flame::Path object to Strings' do
 			('/foo' + @init.call('/bar', 'baz')).should.equal '/foo/bar/baz'
+		end
+	end
+
+	describe '#to_routes_with_endpoint' do
+		it 'should return the nested Hash with path parts as keys with endpoint' do
+			path = @init.call('/foo/bar/baz')
+			routes, endpoint = path.to_routes_with_endpoint
+			routes.should.equal('foo' => { 'bar' => { 'baz' => {} } })
+			endpoint.should.equal({})
+			endpoint.should.be.same_as routes.dig(*path.parts)
 		end
 	end
 end

--- a/spec/unit/router/route_spec.rb
+++ b/spec/unit/router/route_spec.rb
@@ -13,234 +13,42 @@ class RouteController < Flame::Controller
 	def export_cards; end
 end
 
+class AnotherRouteController < Flame::Controller
+	def foo; end
+
+	def bar; end
+end
+
 describe Flame::Router::Route do
 	before do
-		@init = proc do |args = {}|
-			Flame::Router::Route.new(
-				RouteController,
-				args.fetch(:action,      :foo),
-				args.fetch(:method,      :GET),
-				args.fetch(:ctrl_path,   '/foo'),
-				args.fetch(:action_path, '/:first/:second/:?third/:?fourth')
-			)
+		@init = proc do |*args|
+			args = [RouteController, :foo] if args.empty?
+			Flame::Router::Route.new(*args)
 		end
 	end
 
 	describe '#initialize' do
-		it 'should make path' do
-			route = @init.call
-			route.path.should.be.kind_of Flame::Path
-			route.path.should.equal '/foo/:first/:second/:?third/:?fourth'
-		end
-
-		it 'should raise error with extra required path arguments' do
-			lambda {
-				@init.call(
-					ctrl_path: '/foo',
-					action_path: '/:first/:second/:third'
-				)
-			}
-				.should.raise(Flame::Errors::RouteExtraArgumentsError)
-				.message.should match_words('RouteController', 'third')
-		end
-
-		it 'should raise error with extra optional path arguments' do
-			lambda {
-				@init.call(
-					ctrl_path: '/foo',
-					action_path: '/:first/:second/:?third/:?fourth/:?fifth'
-				)
-			}
-				.should.raise(Flame::Errors::RouteExtraArgumentsError)
-				.message.should match_words('RouteController', 'fifth')
-		end
-
-		it 'should raise error for wrong order of optional arguments' do
-			lambda {
-				@init.call(
-					ctrl_path: '/foo',
-					action_path: '/:first/:second/:?fourth/:?third'
-				)
-			}
-				.should.raise(Flame::Errors::RouteArgumentsOrderError)
-				.message.should match_words(
-					"'/:first/:second/:?fourth/:?third'", "third", "fourth"
-				)
-		end
-	end
-
-	describe '#freeze' do
-		it 'should freeze path' do
-			@init.call.path.should.be.frozen
-		end
-	end
-
-	describe '#compare_attributes' do
-		it 'should return true for all correct attributes' do
-			attributes = {
-				controller: RouteController,
-				action: :foo,
-				method: :GET,
-				path: '/foo/first/second/third'
-			}
-			@init.call.compare_attributes(attributes).should.equal attributes
-		end
-
-		it 'should return true for HEAD request instead of GET' do
-			attributes = {
-				controller: RouteController,
-				action: :foo,
-				method: :HEAD,
-				path: '/foo/first/second/third'
-			}
-			@init.call.compare_attributes(attributes).should.equal attributes
-		end
-
-		it 'should return false for HEAD request instead of POST' do
-			route = @init.call(method: :POST)
-			attributes = {
-				controller: RouteController,
-				action: :foo,
-				method: :HEAD,
-				path: '/foo/first/second/third'
-			}
-			route.compare_attributes(attributes).should.equal false
-		end
-
-		it 'should return true for path with duplicates parts' do
-			route = @init.call(
-				action: :foo,
-				ctrl_path: '/foo',
-				action_path: '/foo/:first/:second/:?third'
-			)
-			attributes = {
-				controller: RouteController,
-				action: :foo,
-				method: :GET,
-				path: '/foo/foo/first/second/third'
-			}
-			route.compare_attributes(attributes).should.equal attributes
-		end
-
-		it 'should return true for downcased method' do
-			attributes = {
-				controller: RouteController,
-				action: :foo,
-				method: :get
-			}
-			@init.call.compare_attributes(attributes).should.equal attributes
-		end
-
-		it 'should return true for downcased HEAD request instead of GET' do
-			attributes = {
-				controller: RouteController,
-				action: :foo,
-				method: :head
-			}
-			@init.call.compare_attributes(attributes).should.equal attributes
-		end
-
-		it 'should return false for incorrect controller' do
-			@init.call.compare_attributes(
-				controller: Flame::Controller,
-				action: :foo,
-				method: :GET,
-				path: '/foo/first/second/third'
-			).should.equal false
-		end
-
-		it 'should return false for incorrect action' do
-			@init.call.compare_attributes(
-				controller: RouteController,
-				action: :bar,
-				method: :GET,
-				path: '/foo/first/second/third'
-			).should.equal false
-		end
-
-		it 'should return false for incorrect method' do
-			@init.call.compare_attributes(
-				controller: RouteController,
-				action: :foo,
-				method: :POST,
-				path: '/foo/first/second/third'
-			).should.equal false
-		end
-
-		it 'should return false for incorrect path' do
-			@init.call.compare_attributes(
-				controller: RouteController,
-				action: :foo,
-				method: :GET,
-				path: '/foo/bar'
-			).should.equal false
+		it 'should receive controller and action' do
+			-> { @init.call(RouteController, :foo) }
+				.should.not.raise(ArgumentError)
 		end
 	end
 
 	describe '#==' do
 		it 'should return true for another object with the same attributes' do
-			@init.call.should.equal @init.call
+			@init.call.should == @init.call
 		end
 
-		it 'should return true for another object with different slashes in path' do
-			other = @init.call(
-				ctrl_path: '/foo',
-				action_path: '/:first////:second/:?third//'
-			)
-			@init.call.should.equal other
+		it 'should return false for another object with another controller' do
+			route = @init.call(RouteController, :foo)
+			other = @init.call(AnotherRouteController, :foo)
+			route.should.not == other
 		end
 
-		it 'should return false for another object with another attributes' do
-			other = @init.call(
-				ctrl_path: '/foo',
-				action_path: '/:second/:first/:?third'
-			)
-			@init.call.should.not.equal other
-		end
-	end
-
-	describe '#<=>' do
-		it 'should return -1 for other route with less count of path parts' do
-			(@init.call <=> @init.call(
-				action: :baz,
-				ctrl_path: '/baz',
-				action_path: '/:first/:second'
-			))
-				.should.equal(-1)
-		end
-
-		it 'should return 1 for other route with greater count of path parts' do
-			(@init.call(
-				action: :baz,
-				ctrl_path: '/baz',
-				action_path: '/:first/:second'
-			) <=> @init.call)
-				.should.equal 1
-		end
-
-		it 'should return 0 for other route with equal count of path parts' do
-			bar_route = @init.call(
-				action: :bar,
-				ctrl_path: '/bar',
-				action_path: '/:first/:second/:?third'
-			)
-			(@init.call <=> bar_route)
-				.should.equal 0
-		end
-
-		it 'should return -1 for other route with arguments' do
-			export_route = @init.call(
-				action: :export_cards,
-				ctrl_path: '/route',
-				action_path: '/export_cards'
-			)
-			show_route = @init.call(
-				action: :show,
-				ctrl_path: '/route',
-				action_path: '/:id'
-			)
-			(export_route <=> show_route)
-				.should.equal(-1)
+		it 'should return false for another object with another action' do
+			route = @init.call(RouteController, :foo)
+			other = @init.call(RouteController, :bar)
+			route.should.not == other
 		end
 	end
 end

--- a/spec/unit/router/routes_spec.rb
+++ b/spec/unit/router/routes_spec.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+describe Flame::Router::Routes do
+	before do
+		@init = lambda do |path = '/foo/bar/baz'|
+			Flame::Router::Routes.new(path)
+		end
+		@routes = @init.call
+	end
+
+	it 'should be a kind of Hash' do
+		@routes.should.be.kind_of Hash
+	end
+
+	describe '#initialize' do
+		it 'should receive Flame::Path for building' do
+			path = Flame::Path.new('/foo/bar/baz')
+			@init.call(path)
+				.should.equal('foo' => { 'bar' => { 'baz' => {} } })
+		end
+
+		it 'should receive path as String for building' do
+			@init.call('/foo/bar/baz')
+				.should.equal('foo' => { 'bar' => { 'baz' => {} } })
+		end
+
+		it 'should build nested Hashes as kind of Routes' do
+			deep_check = lambda do |values|
+				values.all? do |value|
+					value.is_a?(Flame::Router::Routes) &&
+						(deep_check.call(value.values) || value.values.empty?)
+				end
+			end
+
+			deep_check.call(@routes.values).should.be.true
+		end
+	end
+
+	describe '#[]' do
+		it 'should works with Path Part for key which is not argument' do
+			path_part = Flame::Path::Part.new('foo')
+			@routes[path_part].should.equal('bar' => { 'baz' => {} })
+		end
+
+		it 'should works with String for key which is not argument ' do
+			@routes['foo'].should.equal('bar' => { 'baz' => {} })
+		end
+
+		it 'should works with Path Part for key which is argument' do
+			path_part = Flame::Path::Part.new('value')
+			routes = @init.call('/:first/:second')
+			routes[path_part].should.equal(':second' => {})
+		end
+
+		it 'should works with String for key which is argument' do
+			routes = @init.call('/:first/:second')
+			routes['value'].should.equal(':second' => {})
+		end
+
+		it 'should works for HTTP-methods as Symbol keys' do
+			routes = @init.call('/foo/bar')
+			routes['foo']['bar'][:GET] = 42
+			routes['foo']['bar'][:GET].should.equal 42
+		end
+	end
+
+	describe '#dig' do
+		it 'should works with Path Part for Path Parts which are not arguments' do
+			path = Flame::Path.new('/foo/bar')
+			@routes.dig(*path.parts).should.equal('baz' => {})
+		end
+
+		it 'should works with String for Path Parts which are not arguments' do
+			@routes.dig('foo', 'bar').should.equal('baz' => {})
+		end
+
+		it 'should works with Path Part for Path Parts which are arguments' do
+			path = Flame::Path.new('/foo/bar')
+			routes = @init.call('/:first/:second/:?third')
+			routes.dig(*path.parts).should.equal(':?third' => {})
+		end
+
+		it 'should works with String for Path Parts which are arguments' do
+			routes = @init.call('/:first/:second/:?third')
+			routes.dig('foo', 'bar').should.equal(':?third' => {})
+		end
+	end
+end


### PR DESCRIPTION
Resolves #3.

**Additional**:

Add `Flame::Router::Routes` inherited from `Hash` for routes collection

Move `Flame::Controller.with_actions` to separate file

Rename `Flame::Path::PathPart` to `Flame::Path::Part`
Freeze `Flame::Path::Part` in initialization
Improve `Flame::Path::Part#opt_arg?` method
Add `Flame::Path::Part#req_arg?` method

Rename `Flame::Router::RouteRefine` to `Flame::Router::RoutesRefine`
Make `Flame::Router::RoutesRefine` private constant

Add some YARD-documentation
Change output style of `bacon`
Add the second `#` for code comments
Replace `recieve` typo with `receive`
Remove commented `binding.pry`
Remove `TODO` section from `README`