### PR TITLE
Remove patch-versions of Ruby for Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: ruby
 rvm:
-  - 2.3.3
-  - 2.4.0
+  - 2.3
+  - 2.4
 
 notifications:
   email:


### PR DESCRIPTION
Use pre-builded versions now.