### PR TITLE
Fix exploit with static files

### DIFF
--- a/lib/flame/dispatcher/static.rb
+++ b/lib/flame/dispatcher/static.rb
@@ -19,6 +19,7 @@ module Flame
 			def try_static(*args)
 				file = find_static(*args)
 				return nil unless file.exist?
+				halt 400 unless file.allowed?
 				return_static(file)
 			end
 
@@ -34,11 +35,16 @@ module Flame
 			class StaticFile
 				def initialize(filename, dir)
 					@filename = filename.to_s
-					@file_path = File.join dir, CGI.unescape(@filename)
+					@directory = File.expand_path dir
+					@file_path = File.expand_path File.join dir, CGI.unescape(@filename)
 				end
 
 				def exist?
 					File.exist?(@file_path) && File.file?(@file_path)
+				end
+
+				def allowed?
+					@file_path.start_with? @directory
 				end
 
 				def mtime

--- a/spec/unit/dispatcher/static_spec.rb
+++ b/spec/unit/dispatcher/static_spec.rb
@@ -24,7 +24,7 @@ describe Flame::Dispatcher::Static do
 	subject(:try_static) { dispatcher.send(:try_static) }
 
 	context 'not cached' do
-		context 'static file ' do
+		context 'static file' do
 			it { is_expected.to eq "Test static\n" }
 		end
 
@@ -74,7 +74,7 @@ describe Flame::Dispatcher::Static do
 		let(:env) { super().merge('HTTP_IF_MODIFIED_SINCE' => file_mtime.httpdate) }
 
 		before do
-			expect { dispatcher.send(:try_static) }.to throw_symbol(:halt)
+			expect { try_static }.to throw_symbol(:halt)
 		end
 
 		context 'cached file' do
@@ -108,5 +108,25 @@ describe Flame::Dispatcher::Static do
 		let(:path) { '/%EF%BF%BD%8%EF%BF%BD' }
 
 		it { expect { subject }.not_to raise_error }
+	end
+
+	context 'file outside public directory' do
+		before do
+			expect { try_static }.to throw_symbol(:halt)
+		end
+
+		let(:path) { '/%2E%2E/%2E%2E/config/example.yml' }
+
+		describe 'status' do
+			subject { dispatcher.status }
+
+			it { is_expected.to eq 400 }
+		end
+
+		describe 'body' do
+			subject { dispatcher.body }
+
+			it { is_expected.to eq '<h1>Bad Request</h1>' }
+		end
 	end
 end


### PR DESCRIPTION
You could get the content of any file from the outside of public directory.

It didn't work with `nginx`, Cloudflare or something else.