### PR TITLE
Catch `SyntaxError` for custom Internal Server Error page

### DIFF
--- a/lib/flame/dispatcher/routes.rb
+++ b/lib/flame/dispatcher/routes.rb
@@ -28,7 +28,7 @@ module Flame
 				# route.execute(self)
 				controller = route.controller.new(self)
 				controller.send(:execute, action)
-			rescue StandardError => exception
+			rescue StandardError, SyntaxError => exception
 				# p 'rescue from dispatcher'
 				dump_error(exception)
 				status 500


### PR DESCRIPTION
Resolve #57 