### PR TITLE
Autoload `Render` module, don't eager require

### DIFF
--- a/lib/flame/controller.rb
+++ b/lib/flame/controller.rb
@@ -4,9 +4,10 @@ require 'forwardable'
 require 'gorilla_patch/namespace'
 
 require_relative 'controller/path_to'
-require_relative 'render'
 
 module Flame
+	autoload :Render, "#{__dir__}/render"
+
 	## Class initialize when Dispatcher found route with it
 	## For new request and response
 	class Controller

--- a/lib/flame/dispatcher/static.rb
+++ b/lib/flame/dispatcher/static.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'cgi'
+
 module Flame
 	class Dispatcher
 		## Module for working with static files

--- a/spec/unit/errors/template_not_found_error_spec.rb
+++ b/spec/unit/errors/template_not_found_error_spec.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative '../../../lib/flame/errors/template_not_found_error'
+
 describe 'Flame::Errors' do
 	describe Flame::Errors::TemplateNotFoundError do
 		subject(:error) do


### PR DESCRIPTION
I think it's unnecessary for API-like usage.

Resolve #54 