### PR TITLE
Build query in `#path_to` from root-Hash

### DIFF
--- a/lib/flame/path.rb
+++ b/lib/flame/path.rb
@@ -120,9 +120,9 @@ module Flame
 			## Not argument
 			return part unless part.arg?
 			## Not required argument
-			return args[part[2..-1].to_sym] if part.opt_arg?
+			return args.delete(part[2..-1].to_sym) if part.opt_arg?
 			## Required argument
-			param = args[part[1..-1].to_sym]
+			param = args.delete(part[1..-1].to_sym)
 			## Required argument is nil
 			error = Errors::ArgumentNotAssignedError.new(@path, part)
 			raise error if param.nil?

--- a/spec/integration/custom_spec.rb
+++ b/spec/integration/custom_spec.rb
@@ -28,6 +28,10 @@ class CustomController < Flame::Controller
 		ERB.new('<% % %>').result(binding)
 	end
 
+	def merge_query_parameter(_id)
+		path_to :merge_query_parameter, params.merge(lang: 'ru')
+	end
+
 	private
 
 	def execute(action)
@@ -206,6 +210,30 @@ describe CustomController do
 
 				it { is_expected.to eq 'Some page about 302 code' }
 			end
+		end
+	end
+
+	describe 'merge query parameter' do
+		before { get path }
+
+		let(:path_without) { '/custom/merge_query_parameter/2?foo=bar' }
+
+		subject { last_response.body }
+
+		shared_examples 'correct path' do
+			it { is_expected.to eq "#{path_without}&lang=ru" }
+		end
+
+		context 'when does not exist' do
+			let(:path) { path_without }
+
+			it_behaves_like 'correct path'
+		end
+
+		context 'when exists' do
+			let(:path) { "#{path_without}&lang=en" }
+
+			it_behaves_like 'correct path'
 		end
 	end
 end

--- a/spec/unit/application_spec.rb
+++ b/spec/unit/application_spec.rb
@@ -307,10 +307,9 @@ describe Flame::Application do
 		context 'nested params' do
 			let(:args) do
 				[
-					ApplicationController, :foo, params: {
-						name: 'world',
-						nested: { some: 'here', another: %w[there maybe] }
-					}
+					ApplicationController, :foo,
+					name: 'world',
+					nested: { some: 'here', another: %w[there maybe] }
 				]
 			end
 


### PR DESCRIPTION
Now building a path with merged query params is easier.

No more `params: {}` in `path_to`.

Resolve #38 