### PR TITLE
Tune `fingerprint_script` for `bundler` cache in Cirrus CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -5,6 +5,9 @@ test_task:
       image: ruby:2.4
   bundle_cache:
     folder: /usr/local/bundle
-    fingerprint_script: echo $CIRRUS_TASK_NAME:$CIRRUS_OS:$RUBY_VERSION
+    fingerprint_script: >
+      echo $CIRRUS_TASK_NAME:$CIRRUS_OS:$RUBY_VERSION &&
+      cat Gemfile &&
+      cat flame.gemspec
     populate_script: bundle update
   test_script: bundle exec rake


### PR DESCRIPTION
Re-hash when dependencies change.

Example of fail: https://cirrus-ci.com/task/6332825649283072