### PR TITLE
Run `Controller#not_found` through `execute` 

### DIFF
--- a/lib/flame/controller.rb
+++ b/lib/flame/controller.rb
@@ -139,7 +139,7 @@ module Flame
 		end
 
 		def not_found
-			body default_body
+			default_body
 		end
 
 		## Default method for Internal Server Error, can be inherited

--- a/lib/flame/dispatcher/routes.rb
+++ b/lib/flame/dispatcher/routes.rb
@@ -45,11 +45,11 @@ module Flame
 				route = router.find_nearest_route(request.path)
 				## Return standard `default_body` if the route not found
 				return default_body unless route
-				controller = route.controller.new(self)
 				## Execute `not_found` method for the founded route
 				if response.not_found?
-					controller.send(:not_found)
+					execute_route(route, :not_found)
 				else
+					controller = route.controller.new(self)
 					body controller.send(:default_body)
 				end
 			end

--- a/spec/integration/custom_spec.rb
+++ b/spec/integration/custom_spec.rb
@@ -36,6 +36,7 @@ class CustomController < Flame::Controller
 
 	def execute(action)
 		@action = action
+		return halt redirect :foo if request.path.include? '/old_foo'
 		super
 	end
 
@@ -53,6 +54,7 @@ class CustomController < Flame::Controller
 
 	def server_error(exception)
 		@exception = exception
+		p exception
 		super
 	end
 end
@@ -234,6 +236,20 @@ describe CustomController do
 			let(:path) { "#{path_without}&lang=en" }
 
 			it_behaves_like 'correct path'
+		end
+	end
+
+	describe 'execute `not_found` through `execute`' do
+		before { get '/custom/old_foo' }
+
+		subject { last_response }
+
+		it { is_expected.to be_redirect }
+
+		describe 'location' do
+			subject { super().location }
+
+			it { is_expected.to eq '/custom/foo' }
 		end
 	end
 end


### PR DESCRIPTION
For found nearest routes.

Now we can write before-hooks in `execute` also for nonexistent pages.