### PR TITLE
Fix Flame::Controller::Actions#inherit_actions

### DIFF
--- a/lib/flame/controller/actions.rb
+++ b/lib/flame/controller/actions.rb
@@ -17,20 +17,37 @@ module Flame
 			## Re-define public instance methods (actions) from parent
 			## @param actions [Array<Symbol>] Actions for inheritance
 			## @param exclude [Array<Symbol>] Actions for excluding from inheritance
+			## @param from [Module]
+			##   Module (or Class) from which actions will be inherited
 			## @example Inherit all parent actions
 			##   class MyController < BaseController
 			##     inherit_actions
 			##   end
 			## @example Inherit certain parent actions
 			##   class MyController < BaseController
-			##     inherit_actions :index, :show
+			##     inherit_actions %i[index show]
 			##   end
 			## @example Inherit all parent actions exclude certain
 			##   class MyController < BaseController
 			##     inherit_actions exclude: %i[edit update]
 			##   end
-			def inherit_actions(actions = superclass.actions, exclude: [])
-				copy_actions_from(superclass, actions - exclude)
+			## @example Inherit certain actions from specific module
+			##   class MyController < BaseController
+			##     inherit_actions %i[index show], from: ModuleWithActions
+			##   end
+			def inherit_actions(actions = nil, exclude: [], from: superclass)
+				actions = from.actions if actions.nil?
+				actions -= exclude
+
+				actions.each do |action|
+					define_method action, from.public_instance_method(action)
+				end
+
+				return unless from.respond_to?(:refined_http_methods)
+
+				refined_http_methods.merge!(
+					from.refined_http_methods.slice(*actions)
+				)
 			end
 
 			## Re-define public instance method from module
@@ -59,12 +76,10 @@ module Flame
 			##   end
 			def with_actions(mod, exclude: [], only: nil)
 				Module.new do
-					define_singleton_method(:included) do |target|
-						target.send(
-							:copy_actions_from, mod,
-							only || mod.public_instance_methods(false) - exclude
-						)
-					end
+					@mod = mod
+					@actions = only || (@mod.public_instance_methods(false) - exclude)
+
+					extend ModuleWithActions
 				end
 			end
 
@@ -73,18 +88,6 @@ module Flame
 			end
 
 			private
-
-			def copy_actions_from(source, actions)
-				actions.each do |action|
-					define_method(action, source.public_instance_method(action))
-				end
-
-				return unless source.respond_to?(:refined_http_methods)
-
-				refined_http_methods.merge!(
-					source.refined_http_methods.slice(*actions)
-				)
-			end
 
 			Flame::Router::HTTP_METHODS.each do |http_method|
 				downcased_http_method = http_method.downcase
@@ -100,6 +103,19 @@ module Flame
 					refined_http_methods[action] = [downcased_http_method, action_path]
 				end
 			end
+
+			## Base module for module `with_actions`
+			module ModuleWithActions
+				using GorillaPatch::Slice
+
+				def included(ctrl)
+					ctrl.include @mod
+
+					ctrl.inherit_actions @actions, from: @mod
+				end
+			end
+
+			private_constant :ModuleWithActions
 		end
 	end
 end

--- a/spec/unit/controller_spec.rb
+++ b/spec/unit/controller_spec.rb
@@ -747,6 +747,11 @@ describe Flame::Controller do
 					expect(inherited_controller.refined_http_methods)
 						.to eq(SomeActions.refined_http_methods)
 				end
+
+				it 'saves private methods' do
+					expect(inherited_controller.private_instance_methods)
+						.to include(*SomeActions.private_instance_methods)
+				end
 			end
 
 			context 'excluded actions' do


### PR DESCRIPTION
When actions inherited from another controller, http methods refinements
did not copied with them. I.e.

```ruby
   class ParentController < Flame::Controller
     patch '/bar', :foo
   end

   class ChildrenController < ParentController
     inherit_actions %i[foo]
   end

   application.path_to ChildrenController, :foo ## => '/children/foo'
   ## Expected '/children/bar'
```

I also want to add a test for this, but don't sure where should it be, because i did not found similar test for `Flame::Controller::Actions#with_actions`