### PR TITLE
Update config for Cirrus CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -5,10 +5,11 @@ test_task:
       image: ruby:2.4
   bundle_cache:
     folder: /usr/local/bundle
-    fingerprint_script: >
-      echo $CIRRUS_TASK_NAME:$CIRRUS_OS:$RUBY_VERSION &&
-      cat Gemfile &&
-      cat flame.gemspec
+    fingerprint_script:
+      - echo $CIRRUS_TASK_NAME:$CIRRUS_OS
+      - ruby -v
+      - cat Gemfile
+      - cat *.gemspec
     populate_script: bundle update
   environment:
     CODECOV_TOKEN: ENCRYPTED[fc3cdd6692dedbd2133ce8100d2cf236617d6acddc313b5f90f1994d3f62400fcc17fa2af079e8568fb3e85ee5803735]


### PR DESCRIPTION
*   Check version of Ruby with `ruby -v` instead of env variable
    (can be useful for non-ruby images).

*   Additionally check version of Bundler for its cache.

*   Output content of any `.gemspec` file.