### PR TITLE
Remove HTML tags (`<h1>`) from default body

### DIFF
--- a/lib/flame/dispatcher.rb
+++ b/lib/flame/dispatcher.rb
@@ -134,7 +134,7 @@ module Flame
 		## Generate default body of error page
 		def default_body
 			# response.headers[Rack::CONTENT_TYPE] = 'text/html'
-			"<h1>#{Rack::Utils::HTTP_STATUS_CODES[status]}</h1>"
+			Rack::Utils::HTTP_STATUS_CODES[status]
 		end
 
 		## All cached tilts (views) for application by Flame::Render

--- a/spec/integration/index_spec.rb
+++ b/spec/integration/index_spec.rb
@@ -44,7 +44,7 @@ describe IndexController do
 			describe 'body' do
 				subject { super().body }
 
-				it { is_expected.to eq '<h1>Not Found</h1>' }
+				it { is_expected.to eq 'Not Found' }
 			end
 		end
 	end

--- a/spec/unit/dispatcher/static_spec.rb
+++ b/spec/unit/dispatcher/static_spec.rb
@@ -126,7 +126,7 @@ describe Flame::Dispatcher::Static do
 		describe 'body' do
 			subject { dispatcher.body }
 
-			it { is_expected.to eq '<h1>Bad Request</h1>' }
+			it { is_expected.to eq 'Bad Request' }
 		end
 	end
 end

--- a/spec/unit/dispatcher_spec.rb
+++ b/spec/unit/dispatcher_spec.rb
@@ -164,13 +164,13 @@ describe Flame::Dispatcher do
 			context 'neither route nor static file was found' do
 				let(:path) { 'bar' }
 
-				it { is_expected.to eq ['<h1>Not Found</h1>'] }
+				it { is_expected.to eq ['Not Found'] }
 			end
 
 			context 'route with required argument and path without' do
 				let(:path) { 'hello' }
 
-				it { is_expected.to eq ['<h1>Not Found</h1>'] }
+				it { is_expected.to eq ['Not Found'] }
 			end
 		end
 
@@ -449,19 +449,19 @@ describe Flame::Dispatcher do
 			context 'status 200' do
 				let(:status) { 200 }
 
-				it { is_expected.to eq '<h1>OK</h1>' }
+				it { is_expected.to eq 'OK' }
 			end
 
 			context 'status 404' do
 				let(:status) { 404 }
 
-				it { is_expected.to eq '<h1>Not Found</h1>' }
+				it { is_expected.to eq 'Not Found' }
 			end
 
 			context 'status 500' do
 				let(:status) { 500 }
 
-				it { is_expected.to eq '<h1>Internal Server Error</h1>' }
+				it { is_expected.to eq 'Internal Server Error' }
 			end
 		end
 
@@ -495,7 +495,7 @@ describe Flame::Dispatcher do
 		describe 'body' do
 			subject { dispatcher.body }
 
-			it { is_expected.to eq '<h1>Bad Request</h1>' }
+			it { is_expected.to eq 'Bad Request' }
 		end
 	end
 end


### PR DESCRIPTION
There is no `Content-Type` HTTP header,
also there is no reason to return exactly HTML content
(Flame can be used only for API or something else).