### PR TITLE
Improve `path_to` for Controllers with arguments in path

### DIFF
--- a/lib/flame/controller.rb
+++ b/lib/flame/controller.rb
@@ -19,6 +19,8 @@ module Flame
 		extend Actions
 
 		class << self
+			attr_accessor :path_arguments
+
 			def path
 				return self::PATH if const_defined?(:PATH)
 
@@ -170,6 +172,12 @@ module Flame
 			body
 		end
 
+		using GorillaPatch::Slice
+
+		def controller_arguments
+			params.slice(*self.class.path_arguments)
+		end
+
 		def extract_params_for(action)
 			## Take parameters from action method
 			parameters = method(action).parameters
@@ -183,11 +191,6 @@ module Flame
 			opt_values.pop while opt_values.last.nil? && !opt_values.empty?
 			## Concat values
 			req_values + opt_values
-		end
-
-		def add_controller_class(args)
-			args.unshift(self.class) if args[0].is_a?(Symbol)
-			args.insert(1, :index) if args[0].is_a?(Class) && !args[1].is_a?(Symbol)
 		end
 	end
 end

--- a/lib/flame/controller/path_to.rb
+++ b/lib/flame/controller/path_to.rb
@@ -11,6 +11,7 @@ module Flame
 			## Look documentation at {Flame::Dispatcher#path_to}
 			def path_to(*args)
 				add_controller_class(args)
+				add_controller_arguments(args)
 				@dispatcher.path_to(*args)
 			end
 
@@ -34,6 +35,19 @@ module Flame
 			end
 
 			private
+
+			def add_controller_class(args)
+				args.unshift(self.class) if args[0].is_a?(Symbol)
+				args.insert(1, :index) if args[0].is_a?(Class) && !args[1].is_a?(Symbol)
+			end
+
+			def add_controller_arguments(args)
+				if args[-1].is_a?(Hash)
+					args[-1] = controller_arguments.merge args[-1]
+				else
+					args.push(controller_arguments)
+				end
+			end
 
 			def build_path_for_url(*args, **options)
 				first_arg = args.first

--- a/lib/flame/path.rb
+++ b/lib/flame/path.rb
@@ -155,7 +155,7 @@ module Flame
 
 					break if part.opt_arg? && @other_parts.count <= @other_index
 
-					@args[part.clean.to_sym] = extract
+					@args[part.to_sym] = extract
 					@index += 1
 				end
 
@@ -236,10 +236,10 @@ module Flame
 			# 	arg? && !opt_arg?
 			# end
 
-			## Path part as a String without arguments characters
-			## @return [String] clean String
-			def clean
-				@part.delete ARG_CHAR + ARG_CHAR_OPT
+			## Path part as a Symbol without arguments characters
+			## @return [Symbol] clean Symbol
+			def to_sym
+				@part.delete(ARG_CHAR + ARG_CHAR_OPT).to_sym
 			end
 		end
 	end

--- a/lib/flame/router/routes_refine.rb
+++ b/lib/flame/router/routes_refine.rb
@@ -28,6 +28,7 @@ module Flame
 					ControllerFinder.new(namespace_name, controller_or_name).controller
 				@namespace_name = @controller.deconstantize
 				@path = Flame::Path.new(path || @controller.path)
+				@controller.path_arguments = @path.parts.select(&:arg?).map(&:to_sym)
 				@routes, @endpoint = @path.to_routes_with_endpoint
 				@reverse_routes = {}
 				@mount_nested = nested

--- a/lib/flame/validators.rb
+++ b/lib/flame/validators.rb
@@ -52,7 +52,7 @@ module Flame
 						next unless part.arg?
 
 						## Memorize arguments
-						hash[part.opt_arg? ? :opt : :req] << part.clean.to_sym
+						hash[part.opt_arg? ? :opt : :req] << part.to_sym
 					end
 			end
 

--- a/spec/integration/crud_spec.rb
+++ b/spec/integration/crud_spec.rb
@@ -30,6 +30,20 @@ module CRUDTest
 		def create
 			'Create nested item'
 		end
+
+		def show(id)
+			path_to :edit, id: id
+		end
+
+		def edit(id); end
+
+		# protected
+		#
+		# def server_error(error)
+		# 	puts error
+		# 	puts error.backtrace
+		# 	super
+		# end
 	end
 
 	## Mount example controller to app
@@ -138,6 +152,22 @@ describe CRUDTest do
 				subject { super().body }
 
 				it { is_expected.to eq 'Create nested item' }
+			end
+		end
+	end
+
+	describe '`path_to` in controller with argument in path' do
+		before { get '/crud/2/nested/3' }
+
+		describe 'last_response' do
+			subject { last_response }
+
+			it { is_expected.to be_ok }
+
+			describe 'body' do
+				subject { super().body }
+
+				it { is_expected.to eq '/crud/2/nested/edit/3' }
 			end
 		end
 	end


### PR DESCRIPTION
When you have Controller mounted with path like
`/users/:user_id/photos`, you earlier have to pass
`user_id: params[:user_id]` each `path_to` call.

Now it's processing automatically.

There are may be edge cases, like one controller at multiple paths,
or dangerous external setting of `Controller.path_arguments`,
but I hope everything will be good and we'll fix any problem.