### PR TITLE
Drop Ruby 2.4 support

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -12,7 +12,6 @@ bundle_cache: &bundle_cache
 test_task:
   container:
     matrix:
-      image: ruby:2.4
       image: ruby:2.5
       image: ruby:2.6
       image: ruby:2.7

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -39,7 +39,7 @@ Style/HashTransformValues:
   Enabled: true
 
 AllCops:
-  TargetRubyVersion: 2.4
+  TargetRubyVersion: 2.5
 
 Metrics/BlockLength:
   Exclude:

--- a/flame.gemspec
+++ b/flame.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
 		'wiki_uri' => 'https://github.com/AlexWayfer/flame/wiki'
 	}
 
-	s.required_ruby_version = '>= 2.4.0'
+	s.required_ruby_version = '>= 2.5'
 
 	s.add_runtime_dependency 'addressable', '~> 2.5'
 	s.add_runtime_dependency 'gorilla_patch', '~> 3.0'


### PR DESCRIPTION
Maintenance of it has been ended: https://www.ruby-lang.org/en/news/2020/03/31/ruby-2-4-10-released/

Also, it'd be great to use `String#delete_suffix`, for example here:
https://github.com/AlexWayfer/flame/pull/125