### PR TITLE
Allow integration with `better_errors` gem

### DIFF
--- a/flame.gemspec
+++ b/flame.gemspec
@@ -44,6 +44,7 @@ Gem::Specification.new do |spec|
 	spec.add_development_dependency 'gem_toys', '~> 0.5.0'
 	spec.add_development_dependency 'toys', '~> 0.11.0'
 
+	spec.add_development_dependency 'better_errors', '~> 2.0'
 	spec.add_development_dependency 'codecov', '~> 0.4.3'
 	spec.add_development_dependency 'rack-test', '~> 1.1'
 	spec.add_development_dependency 'rspec', '~> 3.9'

--- a/lib/flame/controller.rb
+++ b/lib/flame/controller.rb
@@ -152,7 +152,9 @@ module Flame
 		## Default method for Internal Server Error, can be inherited
 		## @param _exception [Exception] exception from code executing
 		## @return [String] content of exception page
-		def server_error(_exception)
+		def server_error(exception)
+			raise exception if Object.const_defined?(:BetterErrors)
+
 			body default_body
 		end
 

--- a/spec/integration/custom_spec.rb
+++ b/spec/integration/custom_spec.rb
@@ -79,8 +79,12 @@ describe CustomTest do
 
 	subject { last_response }
 
+	let(:middlewares) { [] }
+
 	let(:app) do
-		CustomTest::Application.new
+		builder = Rack::Builder.new
+		middlewares.each { |middleware| builder.use middleware }
+		builder.run CustomTest::Application.new
 	end
 
 	describe 'foo' do
@@ -200,6 +204,12 @@ describe CustomTest do
 			end
 		end
 
+		before do
+			hide_const 'BetterErrors' if hide_better_errors
+		end
+
+		let(:hide_better_errors) { true }
+
 		context 'with regular error' do
 			before { get '/custom/error' }
 
@@ -214,6 +224,16 @@ describe CustomTest do
 			let(:exception) { SyntaxError }
 
 			it_behaves_like 'custom 500'
+		end
+
+		## https://github.com/BetterErrors/better_errors/issues/454
+		context 'when there is `BetterErrors`' do
+			subject(:make_request) { get '/custom/error' }
+
+			let(:hide_better_errors) { false }
+			let(:middlewares) { [BetterErrors::Middleware] }
+
+			it { expect { make_request }.to raise_error 'Test' }
 		end
 	end
 

--- a/spec/integration/spec_helper.rb
+++ b/spec/integration/spec_helper.rb
@@ -1,3 +1,4 @@
 # frozen_string_literal: true
 
 require 'rack/test'
+require 'better_errors'


### PR DESCRIPTION
More info here: https://github.com/BetterErrors/better_errors/issues/454

Example:

```ruby
# config.ru

require 'better_errors'
use BetterErrors::Middleware
BetterErrors.application_root = __dir__
```

(I hope I'll not forget to add this to the wiki)